### PR TITLE
Error in the peer-bias example, probably due to search/replace, fixed

### DIFF
--- a/1_causal_salad.r
+++ b/1_causal_salad.r
@@ -218,7 +218,7 @@ abline(a=0,b=1,lty=2)
 # confounded but we do a partial identification analysis
 # we use an informative prior for h (effect of Q)
 
-dat2 <- list( Y=Y , E=E , I=I , id=1:N )
+dat2 <- list( Y=Y , E=E , X=X , id=1:N )
 
 m2 <- ulam(
     alist(

--- a/1_causal_salad.r
+++ b/1_causal_salad.r
@@ -236,7 +236,7 @@ precis(m2,2,omit="Q")
 
 post <- extract.samples(m2)
 
-plot( post$h , post$g , pch=16 , col=grau(0.2) , cex=2 , ylab="effect of I" , xlab="effect of Q" )
+plot( post$h , post$g , pch=16 , col=grau(0.2) , cex=2 , ylab="effect of X" , xlab="effect of Q" )
 abline(h=0,lty=2)
 
 quantile(post$h)

--- a/1_causal_salad.r
+++ b/1_causal_salad.r
@@ -230,7 +230,7 @@ m2 <- ulam(
         h ~ uniform(0,2),
         # Q model
         vector[id]:Q ~ normal(0,1)
-    ) , data=dat2 , chains=4 , cores=4 )
+    ) , data=dat2 , chains=4 , cores=4, cmdstan=TRUE)
 
 precis(m2,2,omit="Q")
 


### PR DESCRIPTION
Dear @rmcelreath, I went through the examples shown in the Science Before Statistics seminar, and found a small mistake in the peer-bias example. They are apparently due to an obsolete variable named `I`, which was later changed probably to `X`. In the current code, the use of variable `I` leads to the error that closure cannot be converted to an integer, becaue `I` is interpreted as a function.

I fixed the issue in this PR. In addition, I used `cmdstan` for the last Bayesian example because rstan reported error.

Please let me know in case you have questions or concerns. I want to thank you for all the great lectures and talks that you share. Keep moving on!